### PR TITLE
add php close tag in options.example.php.txt

### DIFF
--- a/material/options.example.php.txt
+++ b/material/options.example.php.txt
@@ -20,3 +20,4 @@ $GLOBALS['config']['MATERIAL_DATE_FROMNOW'] = false;
 // ex: 'DD/MM/YYYY'.
 // It's used to correctly convert dates to the 'from now' notation.
 $GLOBALS['config']['MATERIAL_DATE_PATTERN'] = 'DD/MM/YYYY HH:mm:ss';
+?>


### PR DESCRIPTION
even if the file can be used as is, without the closing tag.